### PR TITLE
Replaced `npm install` with `npm ci` for CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
       - checkout
       - run:
           name: Download Dependencies
-          command: npm install
+          command: npm ci
       - run:
           name: Run Lints
           command: npm run lint


### PR DESCRIPTION
Closes #5 